### PR TITLE
Replace get_toc_entry with find_toc_entry

### DIFF
--- a/src/archive.rs
+++ b/src/archive.rs
@@ -170,12 +170,12 @@ impl Archive {
     /// # use pgarchive::Archive;
     /// # let mut file = File::open("tests/test.pgdump").unwrap();
     /// # let archive = Archive::parse(&mut file).unwrap();
-    /// let employee_toc = archive.get_toc_entry(pgarchive::Section::Data, "employee");
+    /// let employee_toc = archive.find_toc_entry(pgarchive::Section::Data, "TABLE DATA", "employee");
     /// ```
-    pub fn get_toc_entry(&self, section: Section, tag: &str) -> Option<&TocEntry> {
+    pub fn find_toc_entry(&self, section: Section, desc: &str, tag: &str) -> Option<&TocEntry> {
         self.toc_entries
             .iter()
-            .find(|e| e.section == section && e.tag == tag)
+            .find(|e| e.section == section && e.desc == desc && e.tag == tag)
     }
 
     /// Access data for a TOC entry.
@@ -195,7 +195,7 @@ impl Archive {
     /// # let mut file = File::open("tests/test.pgdump").unwrap();
     /// # let archive = Archive::parse(&mut file).unwrap();
     /// let employee_toc = archive
-    ///         .get_toc_entry(pgarchive::Section::Data, "pizza")
+    ///         .find_toc_entry(pgarchive::Section::Data, "TABLE DATA", "pizza")
     ///         .expect("no data for pizza table present");
     /// let mut data = archive.read_data(&mut file, &employee_toc)?;
     /// let mut buffer = Vec::new();

--- a/src/toc.rs
+++ b/src/toc.rs
@@ -17,7 +17,11 @@ pub struct TocEntry {
     pub had_dumper: bool,
     pub table_oid: u64,
     pub oid: Oid,
+    /// Name of object that is created or modified.
     pub tag: String,
+    /// Type of object that is created or modified.
+    ///
+    /// For example `DATABASE`, `SEQUENCE` or `TABLE DATA`.
     pub desc: String,
     pub section: Section,
     /// SQL statement to create the database object or change a setting.

--- a/tests/data_test.rs
+++ b/tests/data_test.rs
@@ -8,7 +8,7 @@ fn test_table_data() -> Result<(), pgarchive::ArchiveError> {
     let mut f = File::open(cargo_path.join("test.pgdump"))?;
     let archive = pgarchive::Archive::parse(&mut f)?;
     let entry = archive
-        .get_toc_entry(pgarchive::Section::Data, "pizza")
+        .find_toc_entry(pgarchive::Section::Data, "TABLE DATA", "pizza")
         .expect("no data for pizza table present");
     let mut data = archive.read_data(&mut f, &entry)?;
     let mut buffer = Vec::new();


### PR DESCRIPTION
This is a better name, and a better API: multiple TOC entries can have the same name and section, so we need to include the object type (desc) as an extra key.
